### PR TITLE
fix: export UnixFS HAMT

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,9 @@
     "*": {
       ".": [
         "dist/src/lib.d.ts"
+      ],
+      "unixfs": [
+        "dist/src/unixfs.d.ts"
       ]
     }
   },
@@ -56,6 +59,10 @@
     ".": {
       "types": "./dist/src/lib.d.ts",
       "import": "./src/lib.js"
+    },
+    "./unixfs": {
+      "types": "./dist/src/unixfs.d.ts",
+      "import": "./src/unixfs.js"
     }
   },
   "c8": {


### PR DESCRIPTION
Exports the UnixFS HAMT variant as `@perma/map/unixfs`.